### PR TITLE
Fix credit card capture when using from_dictionary

### DIFF
--- a/mundiapi/models/create_credit_card_payment_request.py
+++ b/mundiapi/models/create_credit_card_payment_request.py
@@ -107,7 +107,7 @@ class CreateCreditCardPaymentRequest(object):
         card_id = dictionary.get('card_id')
         card_token = dictionary.get('card_token')
         recurrence = dictionary.get('recurrence')
-        capture = dictionary.get("capture") if dictionary.get("capture") else True
+        capture = bool(dictionary.get('capture', True))
         extended_limit_enabled = dictionary.get('extended_limit_enabled')
         extended_limit_code = dictionary.get('extended_limit_code')
         merchant_category_code = dictionary.get('merchant_category_code')


### PR DESCRIPTION
Currently when using CreateCreditCardPaymentRequest.from_dictionary, the 'capture' key is ignored and the parameter is always set to True. This pull request fixes that.