### PR TITLE
fixed bug when base_controller attempts to raise APIException but the…

### DIFF
--- a/mundiapi/controllers/base_controller.py
+++ b/mundiapi/controllers/base_controller.py
@@ -10,6 +10,7 @@ from mundiapi.api_helper import APIHelper
 from mundiapi.http.http_context import HttpContext
 from mundiapi.http.requests_client import RequestsClient
 from mundiapi.exceptions.error_exception import ErrorException
+from mundiapi.exceptions.api_exception import APIException
 
 class BaseController(object):
 


### PR DESCRIPTION
As the title says, there is a bug on the base_controller file, this module tries to raise an APIException without importing it before.
My proposal it to include an import line on the top of the file, but replacing it to an ErrorException may be a good solution too.